### PR TITLE
[APB-3851][MP] change respond to request link to go to warm up instead of consent

### DIFF
--- a/app/uk/gov/hmrc/agentclientmanagementfrontend/config/ExternalUrls.scala
+++ b/app/uk/gov/hmrc/agentclientmanagementfrontend/config/ExternalUrls.scala
@@ -24,8 +24,11 @@ class ExternalUrls @Inject()(
   @Named("agent-invitations-frontend.external-url") val agentInvitationsFrontendBaseUrl: String,
   @Named("appName") val appName: String) {
 
-  def multiConfirmTermsUrl(clientType: String, uid: String) =
-    s"$agentInvitationsFrontendBaseUrl/invitations/consent/$clientType/$uid"
+  private def normaliseAgentName(agentName: String) =
+    agentName.toLowerCase().replaceAll("\\s+", "-").replaceAll("[^A-Za-z0-9-]", "")
+
+  def warmUpUrl(clientType: String, uid: String, agencyName: String) =
+    s"$agentInvitationsFrontendBaseUrl/invitations/$clientType/$uid/${normaliseAgentName(agencyName)}"
 
   val contactFrontendUrl: String = s"$contactFrontendBaseUrl/contact/problem_reports_"
 

--- a/app/uk/gov/hmrc/agentclientmanagementfrontend/views/authorised_agents.scala.html
+++ b/app/uk/gov/hmrc/agentclientmanagementfrontend/views/authorised_agents.scala.html
@@ -83,7 +83,7 @@
                             <td>@agentReq.agencyName</td>
                             <td>@config.displayDate(Some(agentReq.expiryDate))</td>
                             <td>
-                                <a href=@externalUrls.multiConfirmTermsUrl(agentReq.clientType, agentReq.uid)>
+                                <a href=@externalUrls.warmUpUrl(agentReq.clientType, agentReq.uid, agentReq.agencyName)>
                                     @Messages("client-authorised-agents-table.actions.respond")
                                 </a>
                             </td>


### PR DESCRIPTION
Because of problems with clients potentially not having a high enough confidence level and being rejected as not authenticated on the consent page, they should instead go to warm up where they can be redirected to uplift their confidence level. 