### PR TITLE
[APB-4678][MP] remove check for suspended agent when getting relationship 

### DIFF
--- a/app/uk/gov/hmrc/agentclientmanagementfrontend/models/AuthorisedAgent.scala
+++ b/app/uk/gov/hmrc/agentclientmanagementfrontend/models/AuthorisedAgent.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.agentclientmanagementfrontend.models
 import java.time.LocalDate
 import play.api.libs.json.Json
 
-case class AuthorisedAgent(uuId: String, serviceName: String, agencyName: String, dateFrom: Option[LocalDate], isSuspended: Boolean = false)
+case class AuthorisedAgent(uuId: String, serviceName: String, agencyName: String, dateFrom: Option[LocalDate])
 
 object AuthorisedAgent {
   implicit val format = Json.format[AuthorisedAgent]

--- a/app/uk/gov/hmrc/agentclientmanagementfrontend/models/ClientCache.scala
+++ b/app/uk/gov/hmrc/agentclientmanagementfrontend/models/ClientCache.scala
@@ -20,7 +20,7 @@ import java.time.LocalDate
 import play.api.libs.json.Json
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 
-case class ClientCache(uuId: String, arn: Arn, agencyName: String, service: String, dateAuthorised: Option[LocalDate], isSuspended: Boolean = false)
+case class ClientCache(uuId: String, arn: Arn, agencyName: String, service: String, dateAuthorised: Option[LocalDate])
 
 object ClientCache {
   implicit val format = Json.format[ClientCache]

--- a/app/uk/gov/hmrc/agentclientmanagementfrontend/views/AuthorisedAgentsPageConfig.scala
+++ b/app/uk/gov/hmrc/agentclientmanagementfrontend/views/AuthorisedAgentsPageConfig.scala
@@ -39,12 +39,6 @@ case class AuthorisedAgentsPageConfig(authorisedAgents: Seq[AuthorisedAgent], ag
 
   val authorisedAgentsExist: Boolean = authorisedAgents.nonEmpty
 
-  val nonSuspendedAuthAgents: Seq[AuthorisedAgent] = authorisedAgents.filter(!_.isSuspended)
-
-  val suspendedAuthAgents: Seq[AuthorisedAgent] = authorisedAgents.filter(_.isSuspended)
-
-  val suspendedAuthAgentsExist: Boolean = suspendedAuthAgents.nonEmpty
-
   val pendingNonSuspendedCount: Int = pendingNonSuspendedRequests.length
 
   def displayDate(date: Option[LocalDate]): String = date.fold("")(_.format(dateFormatter))

--- a/app/uk/gov/hmrc/agentclientmanagementfrontend/views/authorised_agents.scala.html
+++ b/app/uk/gov/hmrc/agentclientmanagementfrontend/views/authorised_agents.scala.html
@@ -113,7 +113,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @config.nonSuspendedAuthAgents.map{ authAgent =>
+                        @config.authorisedAgents.map{ authAgent =>
                             <tr>
                                 <td>@authAgent.agencyName</td>
                                 <td>@Messages(s"client-authorised-agents-table-content.${authAgent.serviceName}")</td>
@@ -130,7 +130,7 @@
         </section>
         <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="history">
             <h2 class="margin-top-0">@Messages("client-authorised-agents-table-relationships.tab3.title")</h2>
-            @if(config.nonPendingNonSuspendedRequestsExist || config.suspendedAuthAgentsExist){
+            @if(config.nonPendingNonSuspendedRequestsExist){
                 <p>@Messages("client-authorised-agents-table-relationships.tab3.p")</p>
                 <table class="font-small">
                     <colgroup>
@@ -146,16 +146,6 @@
                         </tr>
                     </thead>
                     <tbody>
-
-                        @config.suspendedAuthAgents.map { suspendedAgent =>
-                            <tr>
-                            <td>@suspendedAgent.agencyName</td>
-                            <td>@Messages(s"client-authorised-agents-table-content.${suspendedAgent.serviceName}")</td>
-                            <td>@Messages(s"client-authorised-agents-table.suspended")<span class="date-hint">
-                            </span></td>
-                            </td></tr>
-                        }
-
 
                         @config.nonPendingNonSuspendedRequests.map { agentReq =>
                             <tr>

--- a/conf/messages
+++ b/conf/messages
@@ -71,7 +71,6 @@ client-authorised-agents-table.Accepted=You accepted this request
 client-authorised-agents-table.Rejected=You declined this request
 client-authorised-agents-table.Expired=This request expired before you responded
 client-authorised-agents-table.Cancelled=This request was cancelled
-client-authorised-agents-table.suspended=HMRC suspended your authorisation
 client-authorised-agents-table.pending.date=Expires: {0}
 client-authorised-agents-table.actions.no-action=No action needed
 client-authorised-agents-table.actions.respond=Respond to request

--- a/it/uk/gov/hmrc/agentclientmanagementfrontend/controllers/ClientRelationshipManagementControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentclientmanagementfrontend/controllers/ClientRelationshipManagementControllerISpec.scala
@@ -275,16 +275,6 @@ class ClientRelationshipManagementControllerISpec
       sessionStoreService.currentSession.clientCache.get.isEmpty shouldBe true
     }
 
-    "if suspension is enabled show tab with suspended agent relationships" in new PendingInvitationsExist(0) with BaseTestSetUp with NoRelationshipsFound {
-      getClientActiveAgentRelationships(serviceItsa, arn1.value, startDateString)
-      givenSuspensionDetails(arn1.value, SuspensionDetails(suspensionStatus = true, Some(Set("ITSA"))))
-      getAgencyNameMap200(arn1, "abc")
-
-      val response = await(doGetRequest(""))
-      response.status shouldBe 200
-      checkResponseBodyWithText(response, "Your activity history", "HMRC suspended your authorisation")
-    }
-
     "500, when Des returns 400" in {
       authorisedAsClientMtdItId(req, mtdItId.value)
       get400ClientActiveAgentRelationships(serviceItsa)


### PR DESCRIPTION
There is now a suspended response from the endpoint to get the status of a relationship. Do not show on MYTA page if relationship is suspended.