### PR TITLE
APB-5655 [CS] remove incorrect serviceId for contact frontend

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -94,7 +94,6 @@ microservice {
 
     contact-frontend {
       external-url = "http://localhost:9250"
-      serviceId = "agent-client-management-frontend"
     }
 
     tax-account-router {
@@ -107,11 +106,6 @@ microservice {
 
   }
 }
-
-contact-frontend {
-  serviceId = "AOSS"
-}
-
 
 metrics {
   name = ${appName}
@@ -185,5 +179,10 @@ login.continue = "http://localhost:9568"
 bas-gateway.url = "http://localhost:9553/bas-gateway/sign-in"
 
 pagination.itemsperpage=10
+
+contact-frontend {
+  serviceId = "AOSS"
+  host = "http://localhost:9250"
+}
 
 betaFeedbackUrl = ${contact-frontend.host}"/contact/beta-feedback?service=AOSS"


### PR DESCRIPTION
See: https://jira.tools.tax.service.gov.uk/browse/DP-901 for more info. It's been flagged that `agent-client-management-frontend` is not attaching the referrer & serviceId correctly

The default `@hmrcReportTechnicalIssueHelper()` is being used and that takes from the config... so I've removed `microservice.services.contact-frontend.serviceId = "agent-client-management-frontend"` even though it shouldn't be able to pick it up.

Looking at previous implementations it looks like the serviceId was "agent-client-management-frontend" 
```
override val contactFrontendAjaxUrl: String =
    s"${contactFrontendUrl}ajax?service=$appName"

```

I think that this should still be 'AOSS', the comment in DP-901 states it's an unexpected new serviceId (the contact-frontend.serviceId is for the DeskPro team to help sort and triage, rather than us as service teams)