### PR TITLE
APB-5509 [CS] remove tracking consent snippet

### DIFF
--- a/app/uk/gov/hmrc/agentclientmanagementfrontend/views/components/head.scala.html
+++ b/app/uk/gov/hmrc/agentclientmanagementfrontend/views/components/head.scala.html
@@ -18,14 +18,10 @@
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcTimeoutDialog
 @import uk.gov.hmrc.agentclientmanagementfrontend.config.AppConfig
 @import uk.gov.hmrc.agentclientmanagementfrontend.controllers.routes
-@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcTrackingConsentSnippet
 
-@this(hmrcTimeoutDialog: HmrcTimeoutDialog, hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet)
-
+@this(hmrcTimeoutDialog: HmrcTimeoutDialog)
 
 @(hasTimeout: Boolean)(implicit appConfig: AppConfig, messages: Messages)
-
-@hmrcTrackingConsentSnippet()
 
 <link rel="stylesheet" type="text/css" href="@controllers.routes.Assets.versioned("stylesheets/application.css")" media="screen">
 


### PR DESCRIPTION
as it is provided by hmrcLayout, otherwise the cookie banner shows up twice